### PR TITLE
Remove CI parallel limit to save user waiting time

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -12,7 +12,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
         python: ["3.9", "3.10", "3.11","3.12", "3.13"]
 


### PR DESCRIPTION
I don't know whether we added this limitation before, but our CI will finish after 20 minutes or more. it because we have 5 python matrix and only 4 parallel slots.

It is a open source project with no limitation for the github action run time, so maybe we could directly remove the parallel for ci

<img width="484" alt="image" src="https://github.com/user-attachments/assets/8596244f-0354-4259-88aa-5d90dfced399" />

we can see in the screenshot above, that the workflow has to wait python 3.13 is finished, and python 3.13 will not run until others four version of python done