### PR TITLE
Support match license by license header

### DIFF
--- a/src/spdx_matcher/data_models.py
+++ b/src/spdx_matcher/data_models.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 
 

--- a/src/spdx_matcher/data_models.py
+++ b/src/spdx_matcher/data_models.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BaseMatcher:
+    id: str
+    name: str
+    template: str
+    text: str
+    exception_template: str
+    exception_text: str
+    regexp_exists: str
+    metadata: str | None = "metadata"
+
+
+@dataclass
+class TextMatcher(BaseMatcher):
+    id: str | None = "TextMatcher"
+    name: str | None = "text"
+    template: str | None = "standardLicenseTemplate"
+    text: str | None = "licenseText"
+    exception_template: str | None = "licenseExceptionTemplate"
+    exception_text: str | None = "licenseExceptionText"
+    regexp_exists: str | None = "textRegexpExists"
+
+
+@dataclass
+class HeaderMatcher(BaseMatcher):
+    id: str | None = "HeaderMatcher"
+    name: str | None = "header"
+    template: str | None = "standardLicenseHeaderTemplate"
+    text: str | None = "standardLicenseHeader"
+    exception_template: str | None = "licenseExceptionHeaderTemplate"
+    exception_text: str | None = "licenseExceptionHeaderText"
+    regexp_exists: str | None = "headerRegexpExists"
+
+
+@dataclass
+class MatchCost:
+    text: float
+    header: float

--- a/tests/APACHE-HEADER.txt
+++ b/tests/APACHE-HEADER.txt
@@ -1,0 +1,13 @@
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/tests/GPL-3.0-Interface-Exception.txt
+++ b/tests/GPL-3.0-Interface-Exception.txt
@@ -1,0 +1,7 @@
+Linking demo statically or dynamically with other modules is making a combined work based on demo. Thus, the terms and conditions of the GNU General Public License cover the whole combination.
+
+As a special exception, the copyright holders of demo give you permission to combine demo program with free software programs or libraries that are released under the GNU LGPL and with independent modules that communicate with demo solely through the demo's interface. You may copy and distribute such a system following the terms of the GNU GPL for demo and the licenses of the other code concerned, provided that you include the source code of that other code when and as the GNU GPL requires distribution of source code and provided that you do not modify the demo's interface.
+
+Note that people who make modified versions of demo are not obligated to grant this special exception for their modified versions; it is their choice whether to do so. The GNU General Public License gives permission to release a modified version without this exception; this exception also makes it possible to release a modified version which carries forward this exception. If you modify the demo's interface, this exception does not apply to your modified version of demo, and you must remove this exception when you distribute your modified version.
+
+This exception is an additional permission under section 7 of the GNU General Public License, version 3 ("GPLv3")


### PR DESCRIPTION
* Add new arg for both `analyse_license_text` and `fuzzy_license_text` determine whether do header matcher or not, default value is True
* Add data_models.py to reduce the complex for full text match and header match
* Add UT for exception match and header match
* Change cache data format, from

```json
{
    "name": "string",
    "licenseText": "string",
    "regexpForMatch": {
        "regexps": [
            "string",
            "string"
        ],
        "finger_prints": [
            "string",
            "string"
        ]
    },
    "matchCost": "float",
    "text_length": "int",
    "matchConfidence": "int",
    "isDeprecatedLicenseId": "bool"
}
```

to

```json
{
    "name": "string",
    "metadata": {
        "licenseText": "string",
        "standardLicenseHeader": "string or null",
        "reference": "string",
        "seeAlso": [
            "string",
            "string"
        ],
        "isDeprecatedLicenseId": "bool"
    },
    "header": {
        "regexpForMatch": {
            "regexps": [
                "string",
                "string"
            ],
            "finger_prints": [
                "string",
                "string"
            ]
        },
        "matchCost": "float",
        "matchConfidence": "int",
        "text_length": "int"
    },
    "headerRegexpExists": "bool",
    "text": {
        "regexpForMatch": {
            "regexps": [
                "string",
                "string"
            ],
            "finger_prints": [
                "string",
                "string"
            ]
        },
        "matchCost": "float",
        "matchConfidence": "int",
        "text_length": "int"
    },
    "textRegexpExists": "bool"
}
```